### PR TITLE
Option to set VM snapshots limit via SYSTEM DS argument

### DIFF
--- a/addon-storpoolrc
+++ b/addon-storpoolrc
@@ -48,6 +48,12 @@ VMSNAPSHOT_ATOMIC=0
 #
 VMSNAPSHOT_DELETE_ON_TERMINATE=1
 
+# Add quota to the count of VM snapshots
+# the limit is set as a number with the VMSNAPSHOT_LIMIT
+# custom attribute attributevariable in the SYSTEM datastore
+#
+VMSNAPSHOT_ENABLE_LIMIT=1
+
 # Change DEV_PREFIX on imported images
 # Uncomment to enable
 #

--- a/tm/storpool/storpool_common.sh
+++ b/tm/storpool/storpool_common.sh
@@ -923,7 +923,8 @@ function oneDatastoreInfo()
                             /DATASTORE/TEMPLATE/SP_API_HTTP_HOST \
                             /DATASTORE/TEMPLATE/SP_API_HTTP_PORT \
                             /DATASTORE/TEMPLATE/SP_AUTH_TOKEN \
-                            /DATASTORE/TEMPLATE/SP_CLONE_GW)
+                            /DATASTORE/TEMPLATE/SP_CLONE_GW \
+                            /DATASTORE/TEMPLATE/VMSNAPSHOT_LIMIT)
     unset i
     DS_NAME="${XPATH_ELEMENTS[i++]}"
     DS_TYPE="${XPATH_ELEMENTS[i++]}"
@@ -945,6 +946,7 @@ function oneDatastoreInfo()
     SP_API_HTTP_PORT="${XPATH_ELEMENTS[i++]}"
     SP_AUTH_TOKEN="${XPATH_ELEMENTS[i++]}"
     SP_CLONE_GW="${XPATH_ELEMENTS[i++]}"
+    VMSNAPSHOT_LIMIT="${XPATH_ELEMENTS[i++]}"
 
     [ -n "$SP_API_HTTP_HOST" ] && export SP_API_HTTP_HOST || unset SP_API_HTTP_HOST
     [ -n "$SP_API_HTTP_PORT" ] && export SP_API_HTTP_PORT || unset SP_API_HTTP_PORT
@@ -958,7 +960,7 @@ function oneDatastoreInfo()
     _MSG+="${DS_SHARED:+SHARED=$DS_SHARED }"
     _MSG+="${SP_SYSTEM:+SP_SYSTEM=$SP_SYSTEM }${SP_CLONE_GW:+SP_CLONE_GW=$SP_CLONE_GW }"
     _MSG+="${EXPORT_BRIDGE_LIST:+EXPORT_BRIDGE_LIST=$EXPORT_BRIDGE_LIST }"
-    _MSG+="${DS_NAME:+NAME='$DS_NAME' }"
+    _MSG+="${DS_NAME:+NAME='$DS_NAME' }${VMSNAPSHOT_LIMIT:+VMSNAPSHOT_LIMIT=$VMSNAPSHOT_LIMIT}"
     if boolTrue "$AUTO_TEMPLATE"; then
         _MSG+="${SP_REPLICATION:+SP_REPLICATION=$SP_REPLICATION }"
         _MSG+="${SP_PLACEALL:+SP_PLACEALL=$SP_PLACEALL }${SP_PLACETAIL:+SP_PLACETAIL=$SP_PLACETAIL }"
@@ -1252,7 +1254,8 @@ oneVmVolumes()
         /VM/TEMPLATE/DISK/FORMAT \
         /VM/TEMPLATE/DISK/TYPE \
         /VM/TEMPLATE/DISK/TARGET \
-        /VM/TEMPLATE/DISK/IMAGE_ID)
+        /VM/TEMPLATE/DISK/IMAGE_ID \
+        /VM/TEMPLATE/SNAPSHOT/SNAPSHOT_ID)
     unset i
     DS_ID="${XPATH_ELEMENTS[i++]}"
     CONTEXT_DISK_ID="${XPATH_ELEMENTS[i++]}"
@@ -1262,6 +1265,7 @@ oneVmVolumes()
     TYPE="${XPATH_ELEMENTS[i++]}"
     TARGET="${XPATH_ELEMENTS[i++]}"
     IMAGE_ID="${XPATH_ELEMENTS[i++]}"
+    SNAPSHOT_ID="${XPATH_ELEMENTS[i++]}"
     _OFS=$IFS
     IFS=';'
     DISK_ID_A=($DISK_ID)
@@ -1270,6 +1274,7 @@ oneVmVolumes()
     TYPE_A=($TYPE)
     TARGET_A=($TARGET)
     IMAGE_ID_A=($IMAGE_ID)
+    SNAPSHOT_ID_A=($SNAPSHOT_ID)
     IFS=$_OFS
     for ID in ${!DISK_ID_A[@]}; do
         IMAGE_ID="${IMAGE_ID_A[$ID]}"

--- a/vmm/kvm/snapshot_create-storpool
+++ b/vmm/kvm/snapshot_create-storpool
@@ -47,6 +47,22 @@ splog "$0 $*"
 if boolTrue "$VMSNAPSHOT_OVERRIDE"; then
     oneVmVolumes "$VM_ID"
     splog "vmDisks:$vmDisks vmVolumes:'$vmVolumes'"
+    if boolTrue "$VMSNAPSHOT_ENABLE_LIMIT"; then
+        oneDatastoreInfo "$DS_ID"
+        if [ -n "$VMSNAPSHOT_LIMIT" ] && \
+           [ "${VMSNAPSHOT_LIMIT//[[:digit:]]}" = "" ]; then
+           if [ $VMSNAPSHOT_LIMIT -lt ${#SNAPSHOT_ID_A[@]} ]; then
+               res= "VM snapshots limit set in SYSTEM DS $DS_ID exceeded! limit:$VMSNAPSHOT_LIMIT < snapshots:${#SNAPSHOT_ID_A[@]}"
+               splog "$res"
+               log "$res"
+               exit 1
+           else
+               res="VM snapshots limit set in SYSTEM_DS $DS_ID: $VMSNAPSHOT_LIMIT >= ${#SNAPSHOT_ID_A[@]}"
+               log "$res"
+               splog "$res"
+           fi
+        fi
+    fi
     ts=$(date +%s)
     res="${VMSNAPSHOT_TAG}-${SNAP_ID}-${ts}"
 


### PR DESCRIPTION
There are no quota for the count of VM snapshots so this workaround
works with global limit set in the SYSTEM datastore - Each VM in this
datastore can have no more than the `VMSNAPSHOT_LIMIT` count of snapshots