### PR TITLE
implement per disk snapshots limit

### DIFF
--- a/tm/storpool/snap_create
+++ b/tm/storpool/snap_create
@@ -73,6 +73,23 @@ DST_HOST=$SRC_HOST
 DST_PATH="$SRC_PATH"
 
 #-------------------------------------------------------------------------------
+# Check snapshots limits
+#-------------------------------------------------------------------------------
+
+if [ -n "$DISKSNAPSHOT_LIMIT" ] && [ "${DISKSNAPSHOT_LIMIT//[[:digit:]]/}" = "" ]; then
+    if [ $DISKSNAPSHOT_LIMIT -ge 0 ] ; then
+        oneVmDiskSnapshots "$VM_ID" "$DISK_ID"
+        if [ ${#DISK_SNAPSHOTS[@]} -gt $DISKSNAPSHOT_LIMIT ]; then
+            source "$TM_PATH/../../scripts_common.sh"
+            msg="DISKSNAPSHOT_LIMIT of $DISKSNAPSHOT_LIMIT snaphosts exceeded!"
+            splog "$msg"
+            error_message "$msg"
+            exit 1
+        fi
+    fi
+fi
+
+#-------------------------------------------------------------------------------
 # Create snapshot
 #-------------------------------------------------------------------------------
 

--- a/tm/storpool/snap_create_live
+++ b/tm/storpool/snap_create_live
@@ -73,6 +73,23 @@ DST_HOST=$SRC_HOST
 DST_PATH="$SRC_PATH"
 
 #-------------------------------------------------------------------------------
+# Check snapshots limits
+#-------------------------------------------------------------------------------
+
+if [ -n "$DISKSNAPSHOT_LIMIT" ] && [ "${DISKSNAPSHOT_LIMIT//[[:digit:]]/}" = "" ]; then
+    if [ $DISKSNAPSHOT_LIMIT -ge 0 ] ; then
+        oneVmDiskSnapshots "$VM_ID" "$DISK_ID"
+        if [ ${#DISK_SNAPSHOTS[@]} -gt $DISKSNAPSHOT_LIMIT ]; then
+            source "$TM_PATH/../../scripts_common.sh"
+            msg="DISKSNAPSHOT_LIMIT of $DISKSNAPSHOT_LIMIT snaphosts exceeded!"
+            splog "$msg"
+            error_message "$msg"
+            exit 1
+        fi
+    fi
+fi
+
+#-------------------------------------------------------------------------------
 # Create snapshot
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
To protect the custom variables to be accessible only by oneadmin group append to '/etc/one/oned.conf' and restart opennebula service:

```
cat >>/etc/one/oned.conf <<EOF
VM_RESTRICTED_ATTR = "CONTEXT/VMSNAPSHOT_LIMIT"
VM_RESTRICTED_ATTR = "CONTEXT/DISKSNAPSHOT_LIMIT"
EOF
systemctl restart opennebula
```

To enable set DISKSNAPSHOT_LIMIT=<number> in the VM context variables