### PR TITLE
F #72: tweak to set q35 pcie root port (OpenNebula/one#4045)

### DIFF
--- a/vmm/kvm/deploy-tweaks.d.example/q35-pcie-root.py
+++ b/vmm/kvm/deploy-tweaks.d.example/q35-pcie-root.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+# -------------------------------------------------------------------------- #
+# Copyright 2015-2019, StorPool (storpool.com)                               #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+from __future__ import print_function
+from sys import argv, stderr
+from xml.etree import ElementTree as ET
+
+ns = {'qemu': 'http://libvirt.org/schemas/domain/qemu/1.0',
+       'one': "http://opennebula.org/xmlns/libvirt/1.0"
+     }
+
+def indent(elem, level=0):
+    i = "\n" + level*"\t"
+    if elem is not None:
+#        if not elem.text or not elem.text.strip():
+#            elem.text = i + "\t"
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level+1)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+
+changed = 0
+
+xmlDomain = argv[1]
+doc = ET.parse(xmlDomain)
+root = doc.getroot()
+
+xmlVm = argv[2]
+vm_element = ET.parse(xmlVm)
+vm = vm_element.getroot()
+
+for prefix, uri in ns.items():
+    ET.register_namespace(prefix, uri)
+
+t_q35_ports_e = vm.find('./USER_TEMPLATE/Q35_PCIE_ROOT_PORTS')
+if t_q35_ports_e is not None:
+    q35_ports = int(t_q35_ports_e.text)
+
+    machine_type = root.find('./os/type')
+    if 'q35' in machine_type.attrib['machine']:
+        new_device = ET.SubElement(root, 'devices', {})
+
+        ET.SubElement(new_device, 'controller', {
+                'type': 'pci',
+                'model': 'pcie-root'
+            })
+        for i in range(0,q35_ports):
+            ET.SubElement(new_device, 'controller', {
+                    'type': 'pci',
+                    'model': 'pcie-root-port'
+                })
+        ET.SubElement(new_device, 'controller', {
+            'type': 'pci',
+            'model': 'pcie-to-pci-bridge'
+        })
+        changed = 1
+
+if changed:
+    indent(root)
+    doc.write(xmlDomain)


### PR DESCRIPTION
Set the number pof ports to allocate via VM's USER_TEMPLATE with variable

Q35_PCIE_ROOT_PORTS=<number>

Where <number> is the number of PCIE root ports to allocate

The variable could be restricted to the _oneadmin_ user by defining in _/etc/one/oned.conf_
`VM_RESTRICTED_ATTR = "Q35_PCIE_ROOT_PORTS"`

Signed-off-by: Anton Todorov <a.todorov@storpool.com>