### PR TITLE
option to disable readonly

### DIFF
--- a/tm/storpool/context
+++ b/tm/storpool/context
@@ -160,8 +160,8 @@ else
 fi
 #-------------------------------------------------------------------------------
 # (re)attach readonly
-#-------------------------------------------------------------------------------
-storpoolVolumeAttach "$SP_VOL" "$DST_HOST" "ro"
+#------------------------------------------------------------------------------
+storpoolVolumeAttach "$SP_VOL" "$DST_HOST" "$READONLY_MODE"
 
 if boolTrue "TAG_CONTEXT_ISO"; then
     storpoolVolumeTag "$SP_VOL" "$VM_ID"

--- a/tm/storpool/ln
+++ b/tm/storpool/ln
@@ -97,7 +97,7 @@ if [ -n "$SIZE" ]; then
 fi
 
 if boolTrue "READONLY"; then
-    SP_MODE="ro"
+    SP_MODE="$READONLY_MODE"
 fi
 
 

--- a/tm/storpool/mv
+++ b/tm/storpool/mv
@@ -241,7 +241,7 @@ if [ "$DS_TEMPLATE_TYPE" = "SYSTEM_DS" ]; then
                     if [ -n "$DETACH_ONLY" ]; then
                         splog "$DETACH_ONLY"
                     else
-                        storpoolVolumeAttach "$SP_VOL" "$DST_HOST" "ro"
+                        storpoolVolumeAttach "$SP_VOL" "$DST_HOST" "$READONLY_MODE"
                         if boolTrue "DO_SYMLINK"; then
                             oneSymlink "$DST_HOST" "$SP_LINK" "$CTX_PATH"
                         fi
@@ -466,7 +466,7 @@ else
             storpoolVolumeClone "$SP_VOL" "$CDROM_VOL" "$SP_TEMPLATE_CD"
             storpoolVolumeTag "$CDROM_VOL" "CDROM" "type"
         fi
-        SP_MODE="ro"
+        SP_MODE="$READONLY_MODE"
         SP_VOL="$CDROM_VOL"
     fi
     storpoolVolumeAttach "$SP_VOL" "$DST_HOST" "$SP_MODE"

--- a/tm/storpool/premigrate
+++ b/tm/storpool/premigrate
@@ -137,7 +137,7 @@ for i in ${!DISK_ID_ARRAY[@]}; do
                 SP_VOL="$CDROM_VOL"
             fi
             if boolTrue "DISK_READONLY_ARRAY[i]"; then
-                SP_MODE="ro"
+                SP_MODE="$READONLY_MODE"
             else
                 SP_MODE=
             fi
@@ -188,7 +188,7 @@ if [ "${DS_TM_MAD:0:8}" = "storpool" ]; then
         DST_PATH="$VM_PATH/disk.${_CONTEXT_DISK_ID}"
         [ -z "$json" ] || json+=","
         [ -n "$DST_CLIENT" ] || DST_CLIENT="$(storpoolClientId "$DST_HOST" "$COMMON_DOMAIN")"
-        json+="$(storpoolVolumeJsonHelper "$SP_VOL" "$DST_CLIENT" "ro")"
+        json+="$(storpoolVolumeJsonHelper "$SP_VOL" "$DST_CLIENT" "$READONLY_MODE")"
 #        oneSymlink "$DST_HOST" "$SP_LINK" "$DST_PATH"
     fi
 

--- a/tm/storpool/storpool_common.sh
+++ b/tm/storpool/storpool_common.sh
@@ -118,6 +118,8 @@ DISK_SNAPSHOT_FSFREEZE=0
 DS_CP_REPORT_FORMAT=1
 # exclude CDROM images from VM Snapshots
 VMSNAPSHOT_EXCLUDE_CDROM=0
+# libvirt 7.0.0 require cdrom volumes to be RW
+READONLY_MODE="rw"
 
 declare -A SYSTEM_COMPATIBLE_DS
 SYSTEM_COMPATIBLE_DS["ceph"]=1

--- a/vmm/kvm/snapshot_revert-storpool
+++ b/vmm/kvm/snapshot_revert-storpool
@@ -112,12 +112,12 @@ EOF
         tb=$(date +%s%N)
         splog "BEGIN snapshot $snap ($tb)"
         volume="${snap%-$SNAP_ID}"
-        [ "${volume%-iso}" = "$volume" ] && mode="rw" || mode="ro"
+        [ "${volume%-iso}" = "$volume" ] && mode="rw" || mode="$READONLY_MODE"
         storpoolVolumeDetach "$volume" "force" "$VMHOST" "all"
         storpoolVolumeInfo "$volume"
         OLD_SIZE_M=$((V_SIZE/1024/1024))
         if [ "$V_TYPE" = "CDROM"  ]; then
-            mode="ro"
+            mode="$READONLY_MODE"
         fi
         tmpVolume="${volume}-${SP_TMP}"
         storpoolRetry volume "$volume" rename "$tmpVolume" >/dev/null || finish=0


### PR DESCRIPTION
default:
READONLY_MODE="rw"

Older installations should require READONLY_MODE="ro"

With libvirt 7.0.0 the following definition is not working with 'ro'
volume:

```xml
    <disk type='block' device='cdrom'>
      <driver name='qemu' type='raw' cache='none' io='native' discard='unmap'/>
      <source dev='/var/lib/one//datastores/0/31/disk.0' index='4'/>
      <backingStore/>
      <target dev='hda' bus='ide'/>
      <readonly/>
      <boot order='1'/>
      <alias name='ide0-0-0'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
```

rising error:

```
2021-06-29T10:16:33.358316Z qemu-kvm: -blockdev {"driver":"host_device","filename":"/var/lib/one//datastores/0/31/disk.0","aio":"native","node-name":"libvirt-4-storage","cache":{"direct":true,"no-flush":false},"auto-read-only":true,"discard":"unmap"}: The device is not writable: Permission denied
```

Signed-off-by: Anton Todorov <a.todorov@storpool.com>